### PR TITLE
Add test project with unit and integration tests

### DIFF
--- a/MaClasse.sln
+++ b/MaClasse.sln
@@ -12,6 +12,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Service.Database", "Service
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Service.Cloudinary", "Service.Cloudinary\Service.Cloudinary.csproj", "{54F3CD75-2A0E-495B-8E41-04FA32729D46}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{FE997744-BC02-4551-B92D-AEFD712DEBBD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,8 +43,12 @@ Global
 		{54F3CD75-2A0E-495B-8E41-04FA32729D46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{54F3CD75-2A0E-495B-8E41-04FA32729D46}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{54F3CD75-2A0E-495B-8E41-04FA32729D46}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{54F3CD75-2A0E-495B-8E41-04FA32729D46}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {54F3CD75-2A0E-495B-8E41-04FA32729D46}.Release|Any CPU.Build.0 = Release|Any CPU
+                {FE997744-BC02-4551-B92D-AEFD712DEBBD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {FE997744-BC02-4551-B92D-AEFD712DEBBD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {FE997744-BC02-4551-B92D-AEFD712DEBBD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {FE997744-BC02-4551-B92D-AEFD712DEBBD}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 	EndGlobalSection
 EndGlobal

--- a/Service.Database/Program.Partial.cs
+++ b/Service.Database/Program.Partial.cs
@@ -1,0 +1,2 @@
+public partial class Program { }
+

--- a/Tests/Integration/LessonControllerTests.cs
+++ b/Tests/Integration/LessonControllerTests.cs
@@ -1,0 +1,58 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
+using Moq;
+using Service.Database.Controllers;
+using Service.Database.Interfaces;
+using Service.Database.Services;
+using MaClasse.Shared.Models.Files;
+using Xunit;
+
+namespace Tests.Integration;
+
+public class LessonControllerTests : IClassFixture<WebApplicationFactory<Service.Database.Program>>
+{
+    private readonly WebApplicationFactory<Service.Database.Program> _factory;
+    private readonly Mock<ILessonRepository> _repoMock = new();
+
+    public LessonControllerTests(WebApplicationFactory<Service.Database.Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(ILessonRepository));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddSingleton(_repoMock.Object);
+                // ensure UserService can be resolved even if not used
+                services.AddSingleton<UserService>(new UserService(new HttpClient(), new ConfigurationBuilder().Build()));
+            });
+        });
+    }
+
+    [Fact]
+    public async Task GetDocument_ReturnsNotFound_WhenMissing()
+    {
+        _repoMock.Setup(r => r.GetDocument(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((Document?)null);
+        var client = _factory.CreateClient();
+        var request = new FileRequestToDatabase { IdUser = "1", Document = new Document { IdDocument = "42" } };
+        var response = await client.PostAsJsonAsync("/api/get-document", request);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetDocument_ReturnsDocument_WhenExists()
+    {
+        var doc = new Document { IdDocument = "42", Name = "Test" };
+        _repoMock.Setup(r => r.GetDocument("42", "1")).ReturnsAsync(doc);
+        var client = _factory.CreateClient();
+        var request = new FileRequestToDatabase { IdUser = "1", Document = new Document { IdDocument = "42" } };
+        var response = await client.PostAsJsonAsync("/api/get-document", request);
+        response.EnsureSuccessStatusCode();
+        var returned = await response.Content.ReadFromJsonAsync<Document>();
+        Assert.Equal("Test", returned?.Name);
+    }
+}
+

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Moq" Version="4.20.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Service.Database\Service.Database.csproj" />
+    <ProjectReference Include="..\Service.Cloudinary\Service.Cloudinary.csproj" />
+    <ProjectReference Include="..\MaClasse.Shared\MaClasse.Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tests/Unit/BlockVacationServiceTests.cs
+++ b/Tests/Unit/BlockVacationServiceTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MaClasse.Shared.Models.Scheduler;
+using Service.Database.Services;
+using Xunit;
+
+namespace Tests.Unit;
+
+public class BlockVacationServiceTests
+{
+    [Fact]
+    public async Task GenerateWeeklyMondaysAsync_ReturnsOccurrences()
+    {
+        var service = new BlockVacationService(null!); // MongoDbContext not needed
+
+        var prototype = new Appointment
+        {
+            Start = new DateTime(2024, 5, 20, 8, 0, 0),
+            End = new DateTime(2024, 5, 20, 10, 0, 0),
+            Text = "Cours",
+            Color = "blue",
+            IdRecurring = "A"
+        };
+
+        var vacation = new Appointment { Start = new DateTime(2024, 6, 10) };
+        var result = await service.GenerateWeeklyMondaysAsync("1", prototype, vacation, new List<Appointment>());
+        Assert.Equal(3, result.Count);
+        Assert.True(result.All(a => a.Text == prototype.Text));
+    }
+
+    [Fact]
+    public async Task GenerateWeeklyMondaysAsync_SkipsBlockedWeeks()
+    {
+        var service = new BlockVacationService(null!);
+        var prototype = new Appointment
+        {
+            Start = new DateTime(2024, 5, 20, 8, 0, 0),
+            End = new DateTime(2024, 5, 20, 10, 0, 0),
+            Text = "Cours",
+            Color = "blue",
+            IdRecurring = "A"
+        };
+        var vacation = new Appointment { Start = new DateTime(2024, 6, 10) };
+        var blocking = new List<Appointment>
+        {
+            new Appointment
+            {
+                Start = new DateTime(2024,5,27),
+                End = new DateTime(2024,6,2)
+            }
+        };
+        var result = await service.GenerateWeeklyMondaysAsync("1", prototype, vacation, blocking);
+        Assert.Equal(2, result.Count);
+        Assert.DoesNotContain(result, a => a.Start.Date == new DateTime(2024,5,27));
+    }
+}
+

--- a/Tests/Unit/CloudRepositoryTests.cs
+++ b/Tests/Unit/CloudRepositoryTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using CloudinaryDotNet;
+using CloudinaryDotNet.Actions;
+using Moq;
+using Service.Cloudinary.Repositories;
+using Service.Database.Services;
+using Xunit;
+using Microsoft.AspNetCore.Http;
+
+namespace Tests.Unit;
+
+public class CloudRepositoryTests
+{
+    [Fact]
+    public async Task RenameFileAsync_ReturnsResult_OnSuccess()
+    {
+        var cloudMock = new Mock<Cloudinary>(new Account("c","k","s"));
+        cloudMock.Setup(c => c.RenameAsync(It.IsAny<RenameParams>(), default))
+            .ReturnsAsync(new RenameResult { StatusCode = System.Net.HttpStatusCode.OK });
+
+        var repo = new CloudRepository(cloudMock.Object, new SlugifyService());
+        var result = await repo.RenameFileAsync("old", "Nouveau Nom.pdf");
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task RenameFileAsync_ReturnsNull_OnFailure()
+    {
+        var cloudMock = new Mock<Cloudinary>(new Account("c","k","s"));
+        cloudMock.Setup(c => c.RenameAsync(It.IsAny<RenameParams>(), default))
+            .ReturnsAsync(new RenameResult { StatusCode = System.Net.HttpStatusCode.BadRequest });
+
+        var repo = new CloudRepository(cloudMock.Object, new SlugifyService());
+        var result = await repo.RenameFileAsync("old", "Nom");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task UploadFileAsync_Throws_OnInvalidFile()
+    {
+        var repo = new CloudRepository(new Mock<Cloudinary>(new Account("c","k","s")).Object, new SlugifyService());
+        await Assert.ThrowsAsync<ArgumentException>(() => repo.UploadFileAsync(null!, "1"));
+    }
+
+    [Fact]
+    public async Task UploadFileAsync_ReturnsNull_ForUnsupportedExtension()
+    {
+        var cloudMock = new Mock<Cloudinary>(new Account("c","k","s"));
+        var file = new FormFile(new MemoryStream(new byte[1]), 0, 1, "data", "file.txt");
+        var repo = new CloudRepository(cloudMock.Object, new SlugifyService());
+        var result = await repo.UploadFileAsync(file, "1");
+        Assert.Null(result);
+    }
+}
+

--- a/Tests/Unit/SlugifyServiceTests.cs
+++ b/Tests/Unit/SlugifyServiceTests.cs
@@ -1,0 +1,18 @@
+using Service.Database.Services;
+using Xunit;
+
+namespace Tests.Unit;
+
+public class SlugifyServiceTests
+{
+    [Theory]
+    [InlineData("Été Document.pdf", "ete_document")]
+    [InlineData("Test File.PNG", "test_file")]
+    public void SlugifyFileName_ReturnsSlugged(string input, string expected)
+    {
+        var service = new SlugifyService();
+        var result = service.SlugifyFileName(input);
+        Assert.Equal(expected, result);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a new `Tests` project targeting .NET 9
- implement unit tests for SlugifyService, BlockVacationService and CloudRepository
- implement integration tests for LessonController using a test web host
- expose partial `Program` class in Service.Database for test hosting

## Testing
- `dotnet test Tests/Tests.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d812d9384832a8864aa2e8a71fb59