### PR TITLE
Improve unit and integration tests

### DIFF
--- a/Tests/Integration/LessonControllerTests.cs
+++ b/Tests/Integration/LessonControllerTests.cs
@@ -99,63 +99,29 @@ public class LessonControllerTests : IClassFixture<WebApplicationFactory<Service
         var resp = await client.PostAsJsonAsync("/api/add-lesson", req);
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
     }
-}
 
-=======
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.DependencyInjection;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
-using Moq;
-using Service.Database.Interfaces;
-using MaClasse.Shared.Models.Files;
-using Microsoft.Extensions.Configuration;
-using Service.Database.Services;
-using Xunit;
-
-namespace Tests.Integration
-{
-    public class LessonControllerTests : IClassFixture<WebApplicationFactory<Service.Database.Program>>
+    [Fact]
+    public async Task DeleteLesson_ReturnsNotFound_WhenMissing()
     {
-        private readonly WebApplicationFactory<Service.Database.Program> _factory;
-        private readonly Mock<ILessonRepository> _repoMock = new();
+        _repoMock.Setup(r => r.GetLesson("A", "1")).ReturnsAsync((Lesson?)null);
+        var client = _factory.CreateClient();
+        var req = new RequestLesson { IdSession = "s", IdAppointement = "A", Lesson = new Lesson() };
+        var resp = await client.PostAsJsonAsync("/api/delete-lesson", req);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
 
-        public LessonControllerTests(WebApplicationFactory<Service.Database.Program> factory)
-        {
-            _factory = factory.WithWebHostBuilder(builder =>
-            {
-                builder.ConfigureServices(services =>
-                {
-                    var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(ILessonRepository));
-                    if (descriptor != null) services.Remove(descriptor);
-                    services.AddSingleton(_repoMock.Object);
-                    // ensure UserService can be resolved even if not used
-                    services.AddSingleton<UserService>(new UserService(new HttpClient(), new ConfigurationBuilder().Build()));                });
-            });
-        }
-
-        [Fact]
-        public async Task GetDocument_ReturnsNotFound_WhenMissing()
-        {
-            _repoMock.Setup(r => r.GetDocument(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((Document?)null);
-            var client = _factory.CreateClient();
-            var request = new FileRequestToDatabase { IdUser = "1", Document = new Document { IdDocument = "42" } };
-            var response = await client.PostAsJsonAsync("/api/get-document", request);
-            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        }
-
-        [Fact]
-        public async Task GetDocument_ReturnsDocument_WhenExists()
-        {
-            var doc = new Document { IdDocument = "42", Name = "Test" };
-            _repoMock.Setup(r => r.GetDocument("42", "1")).ReturnsAsync(doc);
-            var client = _factory.CreateClient();
-            var request = new FileRequestToDatabase { IdUser = "1", Document = new Document { IdDocument = "42" } };
-            var response = await client.PostAsJsonAsync("/api/get-document", request);
-            response.EnsureSuccessStatusCode();
-            var returned = await response.Content.ReadFromJsonAsync<Document>();
-            Assert.Equal("Test", returned?.Name);
-        }
+    [Fact]
+    public async Task DeleteLesson_Deletes_WhenFound()
+    {
+        var lesson = new Lesson { IdLesson = "L", IdAppointment = "A" };
+        _repoMock.Setup(r => r.GetLesson("A", "1")).ReturnsAsync(lesson);
+        _repoMock.Setup(r => r.DeleteLesson(lesson, "1")).ReturnsAsync(lesson);
+        var client = _factory.CreateClient();
+        var req = new RequestLesson { IdSession = "s", IdAppointement = "A", Lesson = lesson };
+        var resp = await client.PostAsJsonAsync("/api/delete-lesson", req);
+        resp.EnsureSuccessStatusCode();
+        _repoMock.Verify(r => r.DeleteLesson(lesson, "1"), Times.Once);
     }
 }
+
+

--- a/Tests/Unit/BlockVacationServiceTests.cs
+++ b/Tests/Unit/BlockVacationServiceTests.cs
@@ -26,7 +26,7 @@ public class BlockVacationServiceTests
         var vacation = new Appointment { Start = new DateTime(2024, 6, 10) };
         var result = await service.GenerateWeeklyMondaysAsync("1", prototype, vacation, new List<Appointment>());
         Assert.Equal(3, result.Count);
-        Assert.True(result.All(a => a.Text == prototype.Text));
+        Assert.Equal(new[]{new DateTime(2024,5,20), new DateTime(2024,5,27), new DateTime(2024,6,3)}, result.Select(r => r.Start.Date));
     }
 
     [Fact]
@@ -51,8 +51,7 @@ public class BlockVacationServiceTests
             }
         };
         var result = await service.GenerateWeeklyMondaysAsync("1", prototype, vacation, blocking);
-        Assert.Equal(2, result.Count);
-        Assert.DoesNotContain(result, a => a.Start.Date == new DateTime(2024,5,27));
+        Assert.Equal(new[]{new DateTime(2024,5,20), new DateTime(2024,6,3)}, result.Select(a=>a.Start.Date));
     }
 }
 

--- a/Tests/Unit/CloudRepositoryTests.cs
+++ b/Tests/Unit/CloudRepositoryTests.cs
@@ -28,5 +28,23 @@ public class CloudRepositoryTests
         var result = await repo.UploadFileAsync(file, "1");
         Assert.Null(result);
     }
+
+    [Fact]
+    public async Task UploadFileAsync_UsesSlugifiedName_ForImage()
+    {
+        var cloudMock = new Mock<Cloudinary>(new Account("c","k","s"));
+        ImageUploadParams? captured = null;
+        cloudMock.Setup(c => c.UploadAsync(It.IsAny<ImageUploadParams>()))
+            .Callback<ImageUploadParams>(p => captured = p)
+            .ReturnsAsync(new ImageUploadResult { PublicId = "id" });
+
+        var repo = new CloudRepository(cloudMock.Object, new SlugifyService());
+        var stream = new MemoryStream(new byte[10]);
+        var file = new FormFile(stream, 0, stream.Length, "data", "Été Image.PNG");
+        await repo.UploadFileAsync(file, "user");
+
+        Assert.NotNull(captured);
+        Assert.Contains("ete_image", captured!.File!.FileName);
+    }
 }
 

--- a/Tests/Unit/VerifyDeleteServiceTests.cs
+++ b/Tests/Unit/VerifyDeleteServiceTests.cs
@@ -48,12 +48,14 @@ public class VerifyDeleteServiceTests
         var result = await service.VerifyDeleteFiles(request);
         Assert.Single(result);
         Assert.Equal("A", result[0].IdDocument);
+        Assert.Equal(2, call);
     }
 
     [Fact]
     public async Task VerifyDeleteFiles_IgnoresFailures()
     {
-        var handler = new ConstantHandler(_ => new HttpResponseMessage(HttpStatusCode.BadRequest));
+        int calls = 0;
+        var handler = new ConstantHandler(r => { calls++; return new HttpResponseMessage(HttpStatusCode.BadRequest); });
         var client = new HttpClient(handler){BaseAddress = new Uri("http://localhost")};
         var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string,string>{{"Url:ApiGateway","http://localhost"}}).Build();
         var service = new VerifyDeleteService(client, config, new UserService(new HttpClient(), config));
@@ -63,5 +65,6 @@ public class VerifyDeleteServiceTests
 
         var result = await service.VerifyDeleteFiles(request);
         Assert.Empty(result);
+        Assert.Equal(1, calls);
     }
 }


### PR DESCRIPTION
## Summary
- refine unit tests to check actual logic
- clean up duplicate integration tests
- add coverage for delete lesson path

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684db578f770832a91a1d2b68877ef97